### PR TITLE
Compute the intrinsic calibration matrix

### DIFF
--- a/src/java_src/ARCameraImageProcessor.java
+++ b/src/java_src/ARCameraImageProcessor.java
@@ -1,0 +1,33 @@
+package org.cs231a.ptam;
+
+public interface ARCameraImageProcessor {
+    /**
+     * Constructs the camera intrinsic transform matrix K.
+     * Will receive intrinsic calibration parameters
+     * [f_x, f_y, c_x, c_y, s]
+     * f_x, f_y are the focal lengths in x and y axis.
+     * c_x, c_y represent the coordinates of the center image point.
+     * s represents skewness.
+     *
+     * API reference:
+     * https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics.html#LENS_INTRINSIC_CALIBRATION
+     * If API not supported by camera fallback to
+     * constructIntrinsicCalibrationMatrixApproximation
+     */
+  void constructIntrinsicCalibrationMatrix(float[] intrinsicCalibrationParameters);
+
+
+  /**
+   * Contructs an approximation to the intrinsic calibration matrix K
+   * This is the fallback to constructIntrinsicCalibrationMatrix in case that the
+   * CameraCharacteristics.LENS_INTRINSIC_CALIBRATION is not supported by this
+   * device's camera.
+   *
+   * Uses focal length f, image width, and image height.
+   *
+   * Assumes that f_x and f_y are equal. f_x == f_y
+   * Assumes that c_x and c_y are exactly on the center of the image.
+   * Assumes no distortion in camera.
+   */
+  void constructIntrinsicCalibrationMatrixApproximation(float focalLength, int width, int height);
+}

--- a/src/java_src/sources.txt
+++ b/src/java_src/sources.txt
@@ -1,3 +1,4 @@
+/home/elhacker/Developer/Android/PTAM/src/java_src/ARCameraImageProcessor.java
 /home/elhacker/Developer/Android/PTAM/src/java_src/AutoFitTextureView.java
 /home/elhacker/Developer/Android/PTAM/src/java_src/ARCameraFragment.java
 /home/elhacker/Developer/Android/PTAM/src/java_src/HelloWorld.java


### PR DESCRIPTION
I was able to compute the intrinsic calibration matrix K

There are a few takeaways:
- Camera2 api supports a method to get the intrinsic parameters f_x, f_y, c_x, c_y, and s by calling `characteristics.get(CameraCharacteristics.LENS_INTRINSIC_CALIBRATION)`. The possible drawback of this function is that not all devices cameras support it.
- There's a fallback to approximate the calibration matrix K with focal length `characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)`, and using image width and height. We can assume focal length x and y are the same f_x = f_y = focalLength. And also assume that center image is c_x = width / 2, c_y = height / 2. We assume no distortions in the camera.